### PR TITLE
0.1.0-alpha07: Add Variational Autoencoder example Ch_84_Generating_Images_With_VAEs, Add ReduceMean to all loss function. 

### DIFF
--- a/src/CntkCatalyst.Examples/CntkCatalyst.Examples.csproj
+++ b/src/CntkCatalyst.Examples/CntkCatalyst.Examples.csproj
@@ -91,7 +91,7 @@
     <Compile Include="DeepLearningFrancoisChollet\Ch_51_Introduction_To_Convnets.cs" />
     <Compile Include="DeepLearningFrancoisChollet\Ch_35_Classifying_Movie_Reviews.cs" />
     <Compile Include="DeepLearningFrancoisChollet\Ch_52_Using_Convnets_With_Small_Datasets.cs" />
-    <Compile Include="GenerativeModels\VAE_MNIST.cs" />
+    <Compile Include="DeepLearningFrancoisChollet\Ch_84_Generating_Images_With_VAEs.cs" />
     <Compile Include="GenerativeModels\GAN_DCGAN.cs" />
     <Compile Include="GenerativeModels\GAN_BasicGAN.cs" />
     <Compile Include="UniformNoiseMinibatchSource.cs" />

--- a/src/CntkCatalyst.Examples/CntkCatalyst.Examples.csproj
+++ b/src/CntkCatalyst.Examples/CntkCatalyst.Examples.csproj
@@ -91,6 +91,7 @@
     <Compile Include="DeepLearningFrancoisChollet\Ch_51_Introduction_To_Convnets.cs" />
     <Compile Include="DeepLearningFrancoisChollet\Ch_35_Classifying_Movie_Reviews.cs" />
     <Compile Include="DeepLearningFrancoisChollet\Ch_52_Using_Convnets_With_Small_Datasets.cs" />
+    <Compile Include="GenerativeModels\VAE_MNIST.cs" />
     <Compile Include="GenerativeModels\GAN_DCGAN.cs" />
     <Compile Include="GenerativeModels\GAN_BasicGAN.cs" />
     <Compile Include="UniformNoiseMinibatchSource.cs" />

--- a/src/CntkCatalyst.Examples/DeepLearningFrancoisChollet/Ch_21_First_Look_At_A_Neural_Network.cs
+++ b/src/CntkCatalyst.Examples/DeepLearningFrancoisChollet/Ch_21_First_Look_At_A_Neural_Network.cs
@@ -110,7 +110,7 @@ namespace CntkCatalyst.Examples.DeepLearningFrancoisChollet
             var streamConfigurations = new List<StreamConfiguration>();
             foreach (var kvp in nameToVariable)
             {
-                var size = kvp.Value.Shape.Dimensions.Aggregate((d1, d2) => d1 * d2);
+                var size = kvp.Value.Shape.TotalSize;
                 var name = kvp.Key;
                 streamConfigurations.Add(new StreamConfiguration(name, size));
             }

--- a/src/CntkCatalyst.Examples/DeepLearningFrancoisChollet/Ch_51_Introduction_To_Convnets.cs
+++ b/src/CntkCatalyst.Examples/DeepLearningFrancoisChollet/Ch_51_Introduction_To_Convnets.cs
@@ -121,7 +121,7 @@ namespace CntkCatalyst.Examples.DeepLearningFrancoisChollet
             var streamConfigurations = new List<StreamConfiguration>();
             foreach (var kvp in nameToVariable)
             {
-                var size = kvp.Value.Shape.Dimensions.Aggregate((d1, d2) => d1 * d2);
+                var size = kvp.Value.Shape.TotalSize;
                 var name = kvp.Key;
                 streamConfigurations.Add(new StreamConfiguration(name, size));
             }

--- a/src/CntkCatalyst.Examples/DeepLearningFrancoisChollet/Ch_84_Generating_Images_With_VAEs.cs
+++ b/src/CntkCatalyst.Examples/DeepLearningFrancoisChollet/Ch_84_Generating_Images_With_VAEs.cs
@@ -8,7 +8,7 @@ using CNTK;
 using CntkCatalyst.LayerFunctions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace CntkCatalyst.Examples.GenerativeModels
+namespace CntkCatalyst.Examples.DeepLearningFrancoisChollet
 {
     /// <summary>
     /// Example based on:

--- a/src/CntkCatalyst.Examples/DeepLearningFrancoisChollet/Ch_84_Generating_Images_With_VAEs.cs
+++ b/src/CntkCatalyst.Examples/DeepLearningFrancoisChollet/Ch_84_Generating_Images_With_VAEs.cs
@@ -26,7 +26,7 @@ namespace CntkCatalyst.Examples.GenerativeModels
     /// https://github.com/Microsoft/CNTK/tree/master/Examples/Image/DataSets/MNIST
     /// </summary>
     [TestClass]
-    public class VAE_MNIST
+    public class Ch_84_Generating_Images_With_VAEs
     {
         [TestMethod]
         public void Run()
@@ -111,7 +111,7 @@ namespace CntkCatalyst.Examples.GenerativeModels
             app.Run(window);
         }
 
-        (Function mean, Function logVariance) Encoder(Function input, int latentSpaceSize, 
+        (Function mean, Function logVariance) Encoder(Function input, int latentSpaceSize,
             Func<CNTKDictionary> weightInit, CNTKDictionary biasInit,
             DeviceDescriptor device, DataType dataType)
         {
@@ -188,7 +188,7 @@ namespace CntkCatalyst.Examples.GenerativeModels
             return new CntkMinibatchSource(minibatchSource, nameToVariable);
         }
 
-        static Dictionary<Variable, Value> SampleMinibatchForGrid(DeviceDescriptor device, 
+        static Dictionary<Variable, Value> SampleMinibatchForGrid(DeviceDescriptor device,
             Variable decoderInputVariable, int gridSize)
         {
             var latentGridData = new float[gridSize * gridSize * 2];

--- a/src/CntkCatalyst.Examples/GenerativeModels/GAN_BasicGAN.cs
+++ b/src/CntkCatalyst.Examples/GenerativeModels/GAN_BasicGAN.cs
@@ -190,7 +190,7 @@ namespace CntkCatalyst.Examples.GenerativeModels
             var streamConfigurations = new List<StreamConfiguration>();
             foreach (var kvp in nameToVariable)
             {
-                var size = kvp.Value.Shape.Dimensions.Aggregate((d1, d2) => d1 * d2);
+                var size = kvp.Value.Shape.TotalSize;
                 var name = kvp.Key;
                 streamConfigurations.Add(new StreamConfiguration(name, size));
             }

--- a/src/CntkCatalyst.Examples/GenerativeModels/GAN_DCGAN.cs
+++ b/src/CntkCatalyst.Examples/GenerativeModels/GAN_DCGAN.cs
@@ -218,7 +218,7 @@ namespace CntkCatalyst.Examples.GenerativeModels
             var streamConfigurations = new List<StreamConfiguration>();
             foreach (var kvp in nameToVariable)
             {
-                var size = kvp.Value.Shape.Dimensions.Aggregate((d1, d2) => d1 * d2);
+                var size = kvp.Value.Shape.TotalSize;
                 var name = kvp.Key;
                 streamConfigurations.Add(new StreamConfiguration(name, size));
             }

--- a/src/CntkCatalyst.Examples/GenerativeModels/VAE_MNIST.cs
+++ b/src/CntkCatalyst.Examples/GenerativeModels/VAE_MNIST.cs
@@ -165,7 +165,7 @@ namespace CntkCatalyst.Examples.GenerativeModels
             var streamConfigurations = new List<StreamConfiguration>();
             foreach (var kvp in nameToVariable)
             {
-                var size = kvp.Value.Shape.Dimensions.Aggregate((d1, d2) => d1 * d2);
+                var size = kvp.Value.Shape.TotalSize;
                 var name = kvp.Key;
                 streamConfigurations.Add(new StreamConfiguration(name, size));
             }

--- a/src/CntkCatalyst.Examples/GenerativeModels/VAE_MNIST.cs
+++ b/src/CntkCatalyst.Examples/GenerativeModels/VAE_MNIST.cs
@@ -85,12 +85,12 @@ namespace CntkCatalyst.Examples.GenerativeModels
             Trace.WriteLine(model.Summary());
 
             // Train the model.
-            model.Fit(trainMinibatchSource, batchSize: 16, epochs: 1,
+            model.Fit(trainMinibatchSource, batchSize: 16, epochs: 10,
                 validationMinibatchSource: testMinibatchSource);
 
-            //// Sample 15x15 images from the latent space.
+            //// Sample 15x15 images across the latent space.
             
-            // Image generation only requires use the decoder part of the network.
+            // Image generation only requires use of the decoder part of the network.
             // Clone and replace the latentSpaceSampler from training with a new decoder input variable. 
             var decoderInputVariable = Variable.InputVariable(latentSpaceSampler.Output.Shape, dataType);
             var replacements = new Dictionary<Variable, Variable>() { { latentSpaceSampler, decoderInputVariable } };
@@ -128,7 +128,8 @@ namespace CntkCatalyst.Examples.GenerativeModels
                  .Conv2D((3, 3), 64, (1, 1), Padding.Zeros, weightInit(), biasInit, device, dataType)
                  .ReLU()
 
-                 .Dense(32, weightInit(), biasInit, device, dataType);
+                 .Dense(32, weightInit(), biasInit, device, dataType)
+                 .ReLU();
 
             var mean = encoderNetwork.Dense(latentSpaceSize, weightInit(), biasInit, device, dataType);
             var logVariance = encoderNetwork.Dense(latentSpaceSize, weightInit(), biasInit, device, dataType);

--- a/src/CntkCatalyst.Examples/GenerativeModels/VAE_MNIST.cs
+++ b/src/CntkCatalyst.Examples/GenerativeModels/VAE_MNIST.cs
@@ -14,6 +14,9 @@ namespace CntkCatalyst.Examples.GenerativeModels
     /// Example based on:
     /// https://github.com/mdabros/deep-learning-with-python-notebooks/blob/master/8.4-generating-images-with-vaes.ipynb
     /// 
+    /// Original VAE papers:
+    /// https://arxiv.org/pdf/1401.4082.pdf
+    /// https://arxiv.org/pdf/1312.6114.pdf
     /// 
     /// </summary>
     [TestClass]

--- a/src/CntkCatalyst.Examples/GenerativeModels/VAE_MNIST.cs
+++ b/src/CntkCatalyst.Examples/GenerativeModels/VAE_MNIST.cs
@@ -1,0 +1,166 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Windows;
+using CNTK;
+using CntkCatalyst.LayerFunctions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CntkCatalyst.Examples.GenerativeModels
+{
+    /// <summary>
+    /// Example based on:
+    /// https://github.com/mdabros/deep-learning-with-python-notebooks/blob/master/8.4-generating-images-with-vaes.ipynb
+    /// 
+    /// 
+    /// </summary>
+    [TestClass]
+    public class VAE_MNIST
+    {
+        [TestMethod]
+        public void Run()
+        {
+            // Prepare data
+            var baseDataDirectoryPath = @"E:\DataSets\Mnist";
+            var trainFilePath = Path.Combine(baseDataDirectoryPath, "Train-28x28_cntk_text.txt");
+            var testFilePath = Path.Combine(baseDataDirectoryPath, "Test-28x28_cntk_text.txt");
+
+            // Define data type and device for the model.
+            var dataType = DataType.Float;
+            var device = DeviceDescriptor.UseDefaultDevice();
+
+            // Setup initializers
+            var random = new Random(232);
+            Func<CNTKDictionary> weightInit = () => Initializers.GlorotUniform(random.Next());
+            var biasInit = Initializers.Zero();
+
+            // Ensure reproducible results with CNTK.
+            CNTKLib.SetFixedRandomSeed((uint)random.Next());
+            CNTKLib.ForceDeterministicAlgorithms();
+
+            // Setup encoder.
+            var encoderInputShape = NDShape.CreateNDShape(new int[] { 28, 28, 1 });
+            var encoderInput = Variable.InputVariable(encoderInputShape, dataType);
+            var scaledEncoderInput = CNTKLib.ElementTimes(Constant.Scalar(0.00390625f, device), encoderInput);
+            var encoderNetwork = Encoder(scaledEncoderInput, weightInit, biasInit, device, dataType);
+
+            // Setup latent variables.
+            var latentSize = 2;
+            var z_mean = encoderNetwork.Dense(latentSize, weightInit(), biasInit, device, dataType);
+            var z_log_var = encoderNetwork.Dense(latentSize, weightInit(), biasInit, device, dataType);
+            var epsilon = CNTKLib.NormalRandom(new int[] { latentSize }, dataType);
+            var z = CNTKLib.Plus(z_mean, CNTKLib.ElementTimes(CNTKLib.Exp(z_log_var), epsilon));
+
+            // Setup decoder            
+            var decoderNetwork = Decoder(z, weightInit, biasInit, device, dataType);
+
+            // Create minibatch source for providing the real images.
+            var nameToVariable = new Dictionary<string, Variable> { { "features", scaledEncoderInput } };
+            var trainMinibatchSource = CreateMinibatchSource(trainFilePath, nameToVariable, randomize: true);
+            var testMinibatchSource = CreateMinibatchSource(testFilePath, nameToVariable, randomize: false);
+
+            // regularization metric
+            var square_ = CNTKLib.Square(z_mean);
+            var exp_ = CNTKLib.Exp(z_log_var);
+            var constant_1 = Constant.Scalar(dataType, 1.0);
+            var diff_ = CNTKLib.Plus(constant_1, z_log_var);
+            diff_ = CNTKLib.Minus(diff_, square_);
+            diff_ = CNTKLib.Minus(diff_, exp_);
+            var constant_2 = Constant.Scalar(dataType, -5e-4);
+            var regularization_metric = CNTKLib.ElementTimes(constant_2, CNTKLib.ReduceMean(diff_, Axis.AllStaticAxes()));
+
+            // overall loss function
+            var crossentropy_loss = Losses.BinaryCrossEntropy(decoderNetwork.Output, scaledEncoderInput);
+            crossentropy_loss = CNTKLib.ReduceMean(crossentropy_loss, Axis.AllStaticAxes());
+            var loss = CNTKLib.Plus(crossentropy_loss, regularization_metric);
+
+            // Setup trainer.
+            var learner = Learners.Adam(decoderNetwork.Parameters(), learningRate: 0.001, momentum: 0.9);
+            var trainer = Trainer.CreateTrainer(decoderNetwork, loss, loss, new List<Learner> { learner });
+            // create model.
+            var model = new Model(trainer, decoderNetwork, dataType, device);
+
+            Trace.WriteLine(model.Summary());
+
+            int epochs = 10;
+            int batchSize = 16;
+
+            model.Fit(trainMinibatchSource, batchSize, epochs, testMinibatchSource);
+            
+            //// Sample 6x6 images from generator.
+            //var samples = 6 * 6;
+            //var batch = noiseMinibatchSource.GetNextMinibatch(samples, device);
+            //var noise = batch.minibatch;
+
+            //var predictor = new Predictor(encoderNetwork, device);
+            //var images = predictor.PredictNextStep(noise);
+            //var imagesData = images.SelectMany(t => t).ToArray();
+
+            //// Show examples
+            //var app = new Application();
+            //var window = new PlotWindowBitMap("Generated Images", imagesData, 28, 28, 1, true);
+            //window.Show();
+            //app.Run(window);
+        }
+
+        Function Encoder(Function input, Func<CNTKDictionary> weightInit, CNTKDictionary biasInit,
+            DeviceDescriptor device, DataType dataType)
+        {
+            var encoderNetwork = input
+                 .Conv2D((3, 3), 32, (1, 1), Padding.Zeros, weightInit(), biasInit, device, dataType)
+                 .ReLU()
+
+                 .Conv2D((3, 3), 64, (2, 2), Padding.Zeros, weightInit(), biasInit, device, dataType)
+                 .ReLU()
+
+                 .Conv2D((3, 3), 64, (1, 1), Padding.Zeros, weightInit(), biasInit, device, dataType)
+                 .ReLU()
+
+                 .Conv2D((3, 3), 64, (1, 1), Padding.Zeros, weightInit(), biasInit, device, dataType)
+                 .ReLU()
+
+                 .Dense(32, weightInit(), biasInit, device, dataType);
+
+            return encoderNetwork;
+        }
+
+        Function Decoder(Function input, Func<CNTKDictionary> weightInit, CNTKDictionary biasInit,
+            DeviceDescriptor device, DataType dataType)
+        {
+            var decoderNetwork = input
+                .Dense(14 * 14 * 64, weightInit(), biasInit, device, dataType)
+                .ReLU()
+
+                .Reshape(NDShape.CreateNDShape(new int[] { 14, 14, 64 }))
+
+                .ConvTranspose2D((3, 3), 32, (2, 2), Padding.Zeros, (28, 28), weightInit(), biasInit, device, dataType)
+
+                .Conv2D((3, 3), 1, (1, 1), Padding.Zeros, weightInit(), biasInit, device, dataType)
+                .Sigmoid();
+
+            return decoderNetwork;
+        }
+
+        CntkMinibatchSource CreateMinibatchSource(string mapFilePath, Dictionary<string, Variable> nameToVariable,
+            bool randomize)
+        {
+            var streamConfigurations = new List<StreamConfiguration>();
+            foreach (var kvp in nameToVariable)
+            {
+                var size = kvp.Value.Shape.Dimensions.Aggregate((d1, d2) => d1 * d2);
+                var name = kvp.Key;
+                streamConfigurations.Add(new StreamConfiguration(name, size));
+            }
+
+            var minibatchSource = MinibatchSource.TextFormatMinibatchSource(
+                mapFilePath,
+                streamConfigurations,
+                MinibatchSource.InfinitelyRepeat,
+                randomize);
+
+            return new CntkMinibatchSource(minibatchSource, nameToVariable);
+        }
+    }
+}

--- a/src/CntkCatalyst.Examples/GenerativeModels/VAE_MNIST.cs
+++ b/src/CntkCatalyst.Examples/GenerativeModels/VAE_MNIST.cs
@@ -21,6 +21,9 @@ namespace CntkCatalyst.Examples.GenerativeModels
     /// Paper using convolutional VAE:
     /// https://arxiv.org/pdf/1609.08976.pdf
     /// 
+    /// This example needs manual download of the MNIST dataset in CNTK format.
+    /// Instruction on how to download and convert the dataset can be found here:
+    /// https://github.com/Microsoft/CNTK/tree/master/Examples/Image/DataSets/MNIST
     /// </summary>
     [TestClass]
     public class VAE_MNIST

--- a/src/CntkCatalyst.Examples/GenerativeModels/VAE_MNIST.cs
+++ b/src/CntkCatalyst.Examples/GenerativeModels/VAE_MNIST.cs
@@ -181,18 +181,22 @@ namespace CntkCatalyst.Examples.GenerativeModels
 
         static Dictionary<Variable, Value> SampleMinibatchForGrid(DeviceDescriptor device, Variable decoderInputVariable, int gridSize)
         {
-            var data = new float[gridSize * gridSize * 2];
-            var sample_start = -2f;
-            var sample_interval_width = 4f;
-            for (int i = 0, pos = 0; i < gridSize; i++)
+            var latentGridData = new float[gridSize * gridSize * 2];
+
+            // Sample latent space in a grid, from -2 to 2, with "gridSize" points in each direction.
+            var sampleStart = -2f;
+            var sampleIntervalWidth = 4f;
+
+            var index = 0;
+            for (int x = 0; x < gridSize; x++)
             {
-                for (int j = 0; j < gridSize; j++)
+                for (int y = 0; y < gridSize; y++)
                 {
-                    data[pos++] = sample_start + (sample_interval_width / (gridSize - 1)) * i;
-                    data[pos++] = sample_start + (sample_interval_width / (gridSize - 1)) * j;
+                    latentGridData[index++] = sampleStart + (sampleIntervalWidth / (gridSize - 1)) * x;
+                    latentGridData[index++] = sampleStart + (sampleIntervalWidth / (gridSize - 1)) * y;
                 }
             }
-            var value = Value.CreateBatch(decoderInputVariable.Shape, data, device);
+            var value = Value.CreateBatch(decoderInputVariable.Shape, latentGridData, device);
 
             var minibatch = new Dictionary<Variable, Value>
             {

--- a/src/CntkCatalyst.Examples/GenerativeModels/VAE_MNIST.cs
+++ b/src/CntkCatalyst.Examples/GenerativeModels/VAE_MNIST.cs
@@ -18,6 +18,9 @@ namespace CntkCatalyst.Examples.GenerativeModels
     /// https://arxiv.org/pdf/1401.4082.pdf
     /// https://arxiv.org/pdf/1312.6114.pdf
     /// 
+    /// Paper using convolutional VAE:
+    /// https://arxiv.org/pdf/1609.08976.pdf
+    /// 
     /// </summary>
     [TestClass]
     public class VAE_MNIST

--- a/src/CntkCatalyst.Examples/GenerativeModels/VAE_MNIST.cs
+++ b/src/CntkCatalyst.Examples/GenerativeModels/VAE_MNIST.cs
@@ -179,7 +179,8 @@ namespace CntkCatalyst.Examples.GenerativeModels
             return new CntkMinibatchSource(minibatchSource, nameToVariable);
         }
 
-        static Dictionary<Variable, Value> SampleMinibatchForGrid(DeviceDescriptor device, Variable decoderInputVariable, int gridSize)
+        static Dictionary<Variable, Value> SampleMinibatchForGrid(DeviceDescriptor device, 
+            Variable decoderInputVariable, int gridSize)
         {
             var latentGridData = new float[gridSize * gridSize * 2];
 

--- a/src/CntkCatalyst.Examples/GenerativeModels/VAE_MNIST.cs
+++ b/src/CntkCatalyst.Examples/GenerativeModels/VAE_MNIST.cs
@@ -89,11 +89,10 @@ namespace CntkCatalyst.Examples.GenerativeModels
                 validationMinibatchSource: testMinibatchSource);
 
             //// Sample 15x15 images from the latent space.
-
-            // Setup decoder input for prediction.
-            // This will only use the decoder part of the network.
+            
+            // Image generation only requires use the decoder part of the network.
+            // Clone and replace the latentSpaceSampler from training with a new decoder input variable. 
             var decoderInputVariable = Variable.InputVariable(latentSpaceSampler.Output.Shape, dataType);
-            // Clone and replace the training input variable with the prediction input variable. 
             var replacements = new Dictionary<Variable, Variable>() { { latentSpaceSampler, decoderInputVariable } };
             var decoder = decoderNetwork.Clone(ParameterCloningMethod.Freeze, replacements);
 

--- a/src/CntkCatalyst.Examples/GenerativeModels/VAE_MNIST.cs
+++ b/src/CntkCatalyst.Examples/GenerativeModels/VAE_MNIST.cs
@@ -51,17 +51,17 @@ namespace CntkCatalyst.Examples.GenerativeModels
             var z_mean = encoderNetwork.Dense(latentSize, weightInit(), biasInit, device, dataType);
             var z_log_var = encoderNetwork.Dense(latentSize, weightInit(), biasInit, device, dataType);
             var epsilon = CNTKLib.NormalRandom(new int[] { latentSize }, dataType);
-            var z = CNTKLib.Plus(z_mean, CNTKLib.ElementTimes(CNTKLib.Exp(z_log_var), epsilon));
+            var z = CNTKLib.Plus(z_mean, CNTKLib.ElementTimes(CNTKLib.Exp(z_log_var), epsilon), "decoderInputNode");
 
             // Setup decoder            
             var decoderNetwork = Decoder(z, weightInit, biasInit, device, dataType);
 
             // Create minibatch source for providing the real images.
-            var nameToVariable = new Dictionary<string, Variable> { { "features", scaledEncoderInput } };
+            var nameToVariable = new Dictionary<string, Variable> { { "features", decoderNetwork.Arguments[0] } };
             var trainMinibatchSource = CreateMinibatchSource(trainFilePath, nameToVariable, randomize: true);
             var testMinibatchSource = CreateMinibatchSource(testFilePath, nameToVariable, randomize: false);
 
-            // regularization metric
+            // Regularization metric
             var square_ = CNTKLib.Square(z_mean);
             var exp_ = CNTKLib.Exp(z_log_var);
             var constant_1 = Constant.Scalar(dataType, 1.0);
@@ -71,7 +71,7 @@ namespace CntkCatalyst.Examples.GenerativeModels
             var constant_2 = Constant.Scalar(dataType, -5e-4);
             var regularization_metric = CNTKLib.ElementTimes(constant_2, CNTKLib.ReduceMean(diff_, Axis.AllStaticAxes()));
 
-            // overall loss function
+            // Overall loss function
             var crossentropy_loss = Losses.BinaryCrossEntropy(decoderNetwork.Output, scaledEncoderInput);
             crossentropy_loss = CNTKLib.ReduceMean(crossentropy_loss, Axis.AllStaticAxes());
             var loss = CNTKLib.Plus(crossentropy_loss, regularization_metric);
@@ -79,30 +79,36 @@ namespace CntkCatalyst.Examples.GenerativeModels
             // Setup trainer.
             var learner = Learners.Adam(decoderNetwork.Parameters(), learningRate: 0.001, momentum: 0.9);
             var trainer = Trainer.CreateTrainer(decoderNetwork, loss, loss, new List<Learner> { learner });
-            // create model.
+            // Create model.
             var model = new Model(trainer, decoderNetwork, dataType, device);
 
             Trace.WriteLine(model.Summary());
 
-            int epochs = 10;
-            int batchSize = 16;
+            // Train the model.
+            model.Fit(trainMinibatchSource, batchSize: 16, epochs: 10,
+                validationMinibatchSource: testMinibatchSource);
 
-            model.Fit(trainMinibatchSource, batchSize, epochs, testMinibatchSource);
+            //// Sample 15x15 images from the latent space.
             
-            //// Sample 6x6 images from generator.
-            //var samples = 6 * 6;
-            //var batch = noiseMinibatchSource.GetNextMinibatch(samples, device);
-            //var noise = batch.minibatch;
+            // Setup decoder input for prediction.
+            var decoderInputNode = decoderNetwork.FindByName("decoderInputNode");
+            var decoderInputVariable = Variable.InputVariable(decoderInputNode.Output.Shape, dataType);
+            var replacements = new Dictionary<Variable, Variable>() { { decoderInputNode, decoderInputVariable } };
+            var decoder = decoderNetwork.Clone(ParameterCloningMethod.Freeze, replacements);
 
-            //var predictor = new Predictor(encoderNetwork, device);
-            //var images = predictor.PredictNextStep(noise);
-            //var imagesData = images.SelectMany(t => t).ToArray();
+            // Sample 15x15 samples from the latent space
+            var minibatch = SampleMinibatchForGrid(device, decoderInputVariable, gridSize: 15);
 
-            //// Show examples
-            //var app = new Application();
-            //var window = new PlotWindowBitMap("Generated Images", imagesData, 28, 28, 1, true);
-            //window.Show();
-            //app.Run(window);
+            // Transform from latent space to images using the decoder.
+            var predictor = new Predictor(decoder, device);
+            var images = predictor.PredictNextStep(minibatch);
+            var imagesData = images.SelectMany(t => t).ToArray();
+
+            // Show the example images.
+            var app = new Application();
+            var window = new PlotWindowBitMap("Generated Images", imagesData, 28, 28, 1, true);
+            window.Show();
+            app.Run(window);
         }
 
         Function Encoder(Function input, Func<CNTKDictionary> weightInit, CNTKDictionary biasInit,
@@ -136,6 +142,7 @@ namespace CntkCatalyst.Examples.GenerativeModels
                 .Reshape(NDShape.CreateNDShape(new int[] { 14, 14, 64 }))
 
                 .ConvTranspose2D((3, 3), 32, (2, 2), Padding.Zeros, (28, 28), weightInit(), biasInit, device, dataType)
+                .ReLU()
 
                 .Conv2D((3, 3), 1, (1, 1), Padding.Zeros, weightInit(), biasInit, device, dataType)
                 .Sigmoid();
@@ -161,6 +168,28 @@ namespace CntkCatalyst.Examples.GenerativeModels
                 randomize);
 
             return new CntkMinibatchSource(minibatchSource, nameToVariable);
+        }
+
+        static Dictionary<Variable, Value> SampleMinibatchForGrid(DeviceDescriptor device, Variable decoderInputVariable, int gridSize)
+        {
+            var data = new float[gridSize * gridSize * 2];
+            var sample_start = -2f;
+            var sample_interval_width = 4f;
+            for (int i = 0, pos = 0; i < gridSize; i++)
+            {
+                for (int j = 0; j < gridSize; j++)
+                {
+                    data[pos++] = sample_start + (sample_interval_width / (gridSize - 1)) * i;
+                    data[pos++] = sample_start + (sample_interval_width / (gridSize - 1)) * j;
+                }
+            }
+            var value = Value.CreateBatch(decoderInputVariable.Shape, data, device);
+
+            var minibatch = new Dictionary<Variable, Value>
+            {
+                { decoderInputVariable, value},
+            };
+            return minibatch;
         }
     }
 }

--- a/src/CntkCatalyst.Examples/UniformNoiseMinibatchSource.cs
+++ b/src/CntkCatalyst.Examples/UniformNoiseMinibatchSource.cs
@@ -35,7 +35,7 @@ namespace CntkCatalyst.Examples
                 var name = kvp.Key;
                 var variable = kvp.Value;
                 var sampleShape = variable.Shape;
-                var totalElementCount = minibatchSizeInSamples * sampleShape.Dimensions.Aggregate((d1, d2) => d1 * d2);
+                var totalElementCount = minibatchSizeInSamples * sampleShape.TotalSize;
 
                 var data = m_nameToData[name];
                 if(data.Length != totalElementCount)

--- a/src/CntkCatalyst/Losses.cs
+++ b/src/CntkCatalyst/Losses.cs
@@ -4,14 +4,14 @@ namespace CntkCatalyst
 {
     public static class Losses
     {
-        public static Function MeanSquaredError(Variable targets, Variable predictions)
+        public static Function MeanSquaredError(Variable predictions, Variable targets)
         {
             var errors = CNTKLib.Minus(targets, predictions);
             var squaredErrors = CNTKLib.Square(errors);
             return ReduceMeanAll(squaredErrors);
         }
 
-        public static Function MeanAbsoluteError(Variable targets, Variable predictions)
+        public static Function MeanAbsoluteError(Variable predictions, Variable targets)
         {
             var errors = CNTKLib.Minus(targets, predictions);
             var absoluteErrors = CNTKLib.Abs(errors);

--- a/src/CntkCatalyst/Losses.cs
+++ b/src/CntkCatalyst/Losses.cs
@@ -4,24 +4,36 @@ namespace CntkCatalyst
 {
     public static class Losses
     {
-        public static Function MeanAbsoluteError(Variable predictions, Variable targets)
+        public static Function MeanSquaredError(Variable targets, Variable predictions)
         {
-            return CNTKLib.ReduceMean(CNTKLib.Abs(CNTKLib.Minus(predictions, targets)), new Axis(-1));
+            var errors = CNTKLib.Minus(targets, predictions);
+            var squaredErrors = CNTKLib.Square(errors);
+            return ReduceMeanAll(squaredErrors);
         }
 
-        public static Function MeanSquaredError(Variable predictions, Variable targets)
+        public static Function MeanAbsoluteError(Variable targets, Variable predictions)
         {
-            return CNTKLib.ReduceMean(CNTKLib.Square(CNTKLib.Minus(predictions, targets)), new Axis(-1));
+            var errors = CNTKLib.Minus(targets, predictions);
+            var absoluteErrors = CNTKLib.Abs(errors);
+            return ReduceMeanAll(absoluteErrors);
         }
 
         public static Function CategoricalCrossEntropy(Variable predictions, Variable targets)
         {
-            return CNTKLib.CrossEntropyWithSoftmax(predictions, targets);
+            var erros = CNTKLib.CrossEntropyWithSoftmax(predictions, targets);
+            return ReduceMeanAll(erros);
         }
 
         public static Function BinaryCrossEntropy(Variable predictions, Variable targets)
         {
-            return CNTKLib.BinaryCrossEntropy(predictions, targets);
+            var errors = CNTKLib.BinaryCrossEntropy(predictions, targets);
+            return ReduceMeanAll(errors);
+        }
+
+        static Function ReduceMeanAll(Function errors)
+        {
+            var allAxes = Axis.AllStaticAxes();
+            return CNTKLib.ReduceMean(errors, allAxes);
         }
     }
 }

--- a/src/CntkCatalyst/Properties/AssemblyInfo.cs
+++ b/src/CntkCatalyst/Properties/AssemblyInfo.cs
@@ -34,4 +34,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.1.0.0")]
 [assembly: AssemblyFileVersion("0.1.0.0")]
-[assembly: AssemblyInformationalVersion("0.1.0-alpha06")]
+[assembly: AssemblyInformationalVersion("0.1.0-alpha07")]


### PR DESCRIPTION
This pull request adds an Variational Autoencoder example based on : [8.4-generating-images-with-vaes](https://github.com/fchollet/deep-learning-with-python-notebooks/blob/master/8.4-generating-images-with-vaes.ipynb).
This is an alternative generative model compared to the GAN examples. 

The pull request contains the following changes:
 - Adds VAE example, in DeepLearningFrancoisChollet name space.
 - Adds ReduceMean operation to all losses.
 
The VAE example is based on the MNIST dataset. Compared to the GAN examples the VAE examples uses the `Model` type for fitting the network, since the network can be trained as a single model rather than the two competing networks in the GAN setup. 

Examples generated from the latent space can be seen in the grid below. The grid of sampled digits shows a completely continuous distribution of the different digit classes, with one digit morphing into another as you follow a path through latent space. Specific directions in this space have a meaning, e.g. there is a direction for "four-ness", "one-ness", etc.

![vae](https://user-images.githubusercontent.com/9001637/50379293-904db580-0646-11e9-9d96-9012dbf8ba9f.PNG)


