### PR TITLE
0.1.0-alpha.9: Update azure-pipeline: Pack only CntkCatalyst Project

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -60,7 +60,7 @@ jobs:
       configuration: '$(buildConfiguration)'
       buildProperties: 'Platform=$(buildPlatform)'
       packDestination: '$(Build.ArtifactStagingDirectory)'
-      packagesToPack: 'src/**/*.csproj;!src/**/*.Test.csproj!src/**/*.Example.csproj'
+      packagesToPack: 'src/CntkCatalyst/CntkCatalyst.csproj'
     condition: and(succeeded(), eq(variables['buildConfiguration'], 'Release'))
     
   - task: NuGetCommand@2

--- a/src/CntkCatalyst/Properties/AssemblyInfo.cs
+++ b/src/CntkCatalyst/Properties/AssemblyInfo.cs
@@ -34,4 +34,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.1.0.0")]
 [assembly: AssemblyFileVersion("0.1.0.0")]
-[assembly: AssemblyInformationalVersion("0.1.0-alpha.8")]
+[assembly: AssemblyInformationalVersion("0.1.0-alpha.9")]


### PR DESCRIPTION
Specify CntkCatalyst as the only project to pack to avoid Examples and Test projects to be published. Previous pattern to avoid selecting these did not work.